### PR TITLE
Updated to work with Sublime Text 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Rainbowth.cache

--- a/Rainbowth.sublime-settings
+++ b/Rainbowth.sublime-settings
@@ -2,6 +2,7 @@
   "palettes":
   {
     "default": ["red", "orange", "yellow", "green", "blue", "indigo", "violet"],
-    "Tomorrow Night": ["#c66", "#de935f", "#ee6", "#b5bd68", "#81a2be", "#b294bb", "#ff69b4", "#8a2be2"]
+    "Tomorrow Night": ["#c66", "#de935f", "#ee6", "#b5bd68", "#81a2be", "#b294bb", "#ff69b4", "#8a2be2"],
+    "Solarized (Light) (SL)": ["#dc322f", "#268bd2", "#cb4b16", "#b58900", "#2aa198", "#859900",  "#6c71c4"]
   }
 }


### PR DESCRIPTION
Hi, I found your plugin to be the only implementation of rainbow parens for Sublime Text, and since it has some minor issues with Python 3, it didn't work in ST3, so I made some fixes to make it work again.

I wouldn't want the good work to go to waste, so if you don't mind I'd also publish it to Package Control.
